### PR TITLE
curl: add libssh2 in PACKAGECONFIG list to enable sftp

### DIFF
--- a/recipes-core/curl/curl_%.bbappend
+++ b/recipes-core/curl/curl_%.bbappend
@@ -1,0 +1,3 @@
+# libssh2 is required if we want
+# to use scp/sftp
+PACKAGECONFIG_append = " libssh2"


### PR DESCRIPTION
This is useful if we want to use an sftp server with SWUpdate

Signed-off-by: Pierre-Jean Texier <pjtexier@koncepto.io>