### PR TITLE
sw-description: use zlib in 'compressed' field

### DIFF
--- a/recipes-core/images/update-image/imx7d-pico/sw-description
+++ b/recipes-core/images/update-image/imx7d-pico/sw-description
@@ -12,7 +12,7 @@ software =
 						type = "raw";
 						sha256 = "@base-image-swupdate-imx7d-pico.ext4.gz";
 						installed-directly = true;
-						compressed = true;
+						compressed = "zlib";
 						device = "/dev/mmcblk2p2";
 					}
 				);
@@ -39,7 +39,7 @@ software =
 						type = "raw";
 						sha256 = "@base-image-swupdate-imx7d-pico.ext4.gz";
 						installed-directly = true;
-						compressed = true;
+						compressed = "zlib";
 						device = "/dev/mmcblk2p3";
 					}
 				);

--- a/recipes-core/images/update-image/imx7s-warp/sw-description
+++ b/recipes-core/images/update-image/imx7s-warp/sw-description
@@ -12,7 +12,7 @@ software =
 						type = "raw";
 						sha256 = "@base-image-swupdate-imx7s-warp.ext4.gz";
 						installed-directly = true;
-						compressed = true;
+						compressed = "zlib";
 						device = "/dev/mmcblk1p2";
 					}
 				);
@@ -39,7 +39,7 @@ software =
 						type = "raw";
 						sha256 = "@base-image-swupdate-imx7s-warp.ext4.gz";
 						installed-directly = true;
-						compressed = true;
+						compressed = "zlib";
 						device = "/dev/mmcblk1p3";
 					}
 				);

--- a/recipes-core/images/update-image/stm32mp157a-dk1/sw-description
+++ b/recipes-core/images/update-image/stm32mp157a-dk1/sw-description
@@ -12,7 +12,7 @@ software =
 						type = "raw";
 						sha256 = "@base-image-swupdate-stm32mp157a-dk1.ext4.gz";
 						installed-directly = true;
-						compressed = true;
+						compressed = "zlib";
 						device = "/dev/mmcblk0p5";
 					}
 				);
@@ -39,7 +39,7 @@ software =
 						type = "raw";
 						sha256 = "@base-image-swupdate-stm32mp157a-dk1.ext4.gz";
 						installed-directly = true;
-						compressed = true;
+						compressed = "zlib";
 						device = "/dev/mmcblk0p6";
 					}
 				);

--- a/recipes-core/images/update-image/stm32mp157c-dk2/sw-description
+++ b/recipes-core/images/update-image/stm32mp157c-dk2/sw-description
@@ -12,7 +12,7 @@ software =
 						type = "raw";
 						sha256 = "@base-image-swupdate-stm32mp157c-dk2.ext4.gz";
 						installed-directly = true;
-						compressed = true;
+						compressed = "zlib";
 						device = "/dev/mmcblk0p5";
 					}
 				);
@@ -39,7 +39,7 @@ software =
 						type = "raw";
 						sha256 = "@base-image-swupdate-stm32mp157c-dk2.ext4.gz";
 						installed-directly = true;
-						compressed = true;
+						compressed = "zlib";
 						device = "/dev/mmcblk0p6";
 					}
 				);


### PR DESCRIPTION
Since commit in [1], we have to specify the 'compressed' field with a standard value:

 - zlib
or
 - zstd

So let's update our configuration with zlib.

Fixes:

[WARN ] : SWUPDATE running :  [copyfile] : compressed argument: boolean form is deprecated, use the string form

[1] - https://github.com/sbabic/swupdate/commit/7da867e6e602415f8daafb0b4ec5700fc847f2ca#diff-0f146be3fa4bfc41c5f591edfcafa7fc

Signed-off-by: Pierre-Jean Texier <pjtexier@koncepto.io>