### PR TITLE
README: add missing stm32mp157c-dk2 in supported boards

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Supported boards:
 imx7s-warp
 imx7d-pico
 stm32mp157a-dk1
+stm32mp157c-dk2
 ```
 
 Build


### PR DESCRIPTION
Signed-off-by: Joris Offouga <offougajoris@gmail.com>